### PR TITLE
Use the "slim" Debian variant for our build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:stretch
+FROM docker.io/debian:stretch-slim
 
 ARG cores=4
 


### PR DESCRIPTION
I found recently that this exists, and it seems like a good idea to try and use this one.  Alternatively, we could just grab the `dpkg.cfg` that they use and throw that into this base image.

What this means is:

```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
748b9fe0b333        2 days ago          |1 cores=4 /bin/sh -c apt-get update     && …   261MB
<missing>           2 days ago          /bin/sh -c #(nop)  ARG cores=4                  0B
<missing>           3 days ago          /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>           3 days ago          /bin/sh -c #(nop) ADD file:b380df301ccb5ca09…   100MB
```

becomes

```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
8cd736aa0afd        4 minutes ago       |1 cores=4 /bin/sh -c apt-get update     && …   231MB
a022c9e2a323        5 minutes ago       /bin/sh -c #(nop)  ARG cores=4                  0B
dd99abd0503e        3 days ago          /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>           3 days ago          /bin/sh -c #(nop) ADD file:e3250bb9848f956bd…   55.3MB
```

More explicitly, we shave off `30MB` from our own install process, and a whole `45 MB` from the base image that we use.

Furthermore, by doing this, we would include the following in `/etc/dpkg/dpkg.cfg.d/docker`, which is sufficient to prevent documentation, etc. from being installed when we install packages further down the line.

```
# This is the "slim" variant of the Debian base image.
# Many files which are normally unnecessary in containers are excluded,
# and this configuration file keeps them that way.

# dpkg -S '/usr/share/doc/*'
# […]
path-exclude /usr/share/doc/*

# dpkg -S '/usr/share/groff/*'
# […]
path-exclude /usr/share/groff/*

# dpkg -S '/usr/share/info/*'
# […]
path-exclude /usr/share/info/*

# dpkg -S '/usr/share/linda/*'
# […]
path-exclude /usr/share/linda/*

# dpkg -S '/usr/share/lintian/*'
# […]
path-exclude /usr/share/lintian/*

# dpkg -S '/usr/share/locale/*'
# […]
path-exclude /usr/share/locale/*

# dpkg -S '/usr/share/man/*'
# […]
path-exclude /usr/share/man/*

# always include these files, especially for license compliance
path-include /usr/share/doc/*/copyright
```

Rather than rolling our own distribution modifications, this might be sufficient.  I'm open to ideas.